### PR TITLE
Changes sandbox URL to new billwerk.com Domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - create orders without a contract_id
+- changes sandbox url from sandbox.pactas.com to sandbox.billwerk.com
 
 -----------------------------------------------------------------------------------------
 

--- a/lib/pactas_itero/default.rb
+++ b/lib/pactas_itero/default.rb
@@ -7,7 +7,7 @@ module PactasItero
   # Default configuration options for {Client}
   module Default
 
-    SANDBOX_API_ENDPOINT = "https://sandbox.pactas.com".freeze
+    SANDBOX_API_ENDPOINT = "https://sandbox.billwerk.com".freeze
 
     PRODUCTION_API_ENDPOINT = "https://itero.pactas.com".freeze
 

--- a/spec/pactas_itero/api/oauth_spec.rb
+++ b/spec/pactas_itero/api/oauth_spec.rb
@@ -5,7 +5,7 @@ describe PactasItero::Api::OAuth do
   describe '#token' do
     before do
       stub_post(
-        "https://a_client_id:a_client_secret@sandbox.pactas.com/oauth/token"
+        "https://a_client_id:a_client_secret@sandbox.billwerk.com/oauth/token"
       ).with(
         :body => { :grant_type => 'client_credentials' }
       ).to_return(
@@ -23,7 +23,7 @@ describe PactasItero::Api::OAuth do
       client.token
 
       expect(a_post(
-        "https://a_client_id:a_client_secret@sandbox.pactas.com/oauth/token"
+        "https://a_client_id:a_client_secret@sandbox.billwerk.com/oauth/token"
       ).with(
         :body => "grant_type=client_credentials",
         :headers => {

--- a/spec/pactas_itero/api/oauth_spec.rb
+++ b/spec/pactas_itero/api/oauth_spec.rb
@@ -4,9 +4,7 @@ describe PactasItero::Api::OAuth do
 
   describe '#token' do
     before do
-      stub_post(
-        "https://a_client_id:a_client_secret@sandbox.billwerk.com/oauth/token"
-      ).with(
+      stub_post("https://a_client_id:a_client_secret@sandbox.billwerk.com/oauth/token").with(
         :body => { :grant_type => 'client_credentials' }
       ).to_return(
         :status => 200,
@@ -22,9 +20,7 @@ describe PactasItero::Api::OAuth do
 
       client.token
 
-      expect(a_post(
-        "https://a_client_id:a_client_secret@sandbox.billwerk.com/oauth/token"
-      ).with(
+      expect(a_post("https://a_client_id:a_client_secret@sandbox.billwerk.com/oauth/token").with(
         :body => "grant_type=client_credentials",
         :headers => {
           'Content-Type'=>'application/x-www-form-urlencoded; charset=UTF-8'

--- a/spec/pactas_itero/client_spec.rb
+++ b/spec/pactas_itero/client_spec.rb
@@ -194,7 +194,7 @@ describe PactasItero::Client do
     it 'uses the sandbox endpoint by default' do
       client = PactasItero::Client.new
 
-      expect(client.api_endpoint).to eq 'https://sandbox.billwerk.com/'
+      expect(client.api_endpoint).to eq "https://sandbox.billwerk.com/"
     end
 
     it "uses the production endpoint when production is set to true" do
@@ -270,7 +270,8 @@ describe PactasItero::Client do
 
       expect { client.get('/with_message') }.to raise_error(
         PactasItero::UnprocessableEntity,
-        "GET https://sandbox.billwerk.com/with_message: 422 - 'Something' is not a valid ObjectId. Expected a 24 digit hex string."
+        "GET https://sandbox.billwerk.com/with_message: " \
+          "422 - 'Something' is not a valid ObjectId. Expected a 24 digit hex string.",
       )
     end
 
@@ -301,7 +302,7 @@ describe PactasItero::Client do
     it 'returns url of the sandbox endpoint' do
       client = PactasItero::Client.new
 
-      expect(client.sandbox_api_endpoint).to eq 'https://sandbox.billwerk.com'
+      expect(client.sandbox_api_endpoint).to eq "https://sandbox.billwerk.com"
     end
   end
 

--- a/spec/pactas_itero/client_spec.rb
+++ b/spec/pactas_itero/client_spec.rb
@@ -194,7 +194,7 @@ describe PactasItero::Client do
     it 'uses the sandbox endpoint by default' do
       client = PactasItero::Client.new
 
-      expect(client.api_endpoint).to eq 'https://sandbox.pactas.com/'
+      expect(client.api_endpoint).to eq 'https://sandbox.billwerk.com/'
     end
 
     it "uses the production endpoint when production is set to true" do
@@ -270,7 +270,7 @@ describe PactasItero::Client do
 
       expect { client.get('/with_message') }.to raise_error(
         PactasItero::UnprocessableEntity,
-        "GET https://sandbox.pactas.com/with_message: 422 - 'Something' is not a valid ObjectId. Expected a 24 digit hex string."
+        "GET https://sandbox.billwerk.com/with_message: 422 - 'Something' is not a valid ObjectId. Expected a 24 digit hex string."
       )
     end
 
@@ -301,7 +301,7 @@ describe PactasItero::Client do
     it 'returns url of the sandbox endpoint' do
       client = PactasItero::Client.new
 
-      expect(client.sandbox_api_endpoint).to eq 'https://sandbox.pactas.com'
+      expect(client.sandbox_api_endpoint).to eq 'https://sandbox.billwerk.com'
     end
   end
 


### PR DESCRIPTION
Pactas has changed it's name to billwerk and as a first step the sandbox
is now available at a new domain: sandbox.billwerk.com

This commit updates the sandbox URL.