### PR TITLE
Add SelfServiceToken call to contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [UNRELEASED]
 ### Added
+- get a self service token for a given contract
 
 ### Changed
 

--- a/lib/pactas_itero/api/contracts.rb
+++ b/lib/pactas_itero/api/contracts.rb
@@ -25,6 +25,11 @@ module PactasItero
         options = options.camelize_keys
         get "api/v1/contracts/#{contract_id}/cancellationPreview", options
       end
+
+      def get_self_service_token_for_contract(contract_id, options = {})
+        options = options.camelize_keys
+        get "api/v1/contracts/#{contract_id}/SelfServiceToken", options
+      end
     end
   end
 end

--- a/spec/fixtures/self_service_token.json
+++ b/spec/fixtures/self_service_token.json
@@ -1,0 +1,6 @@
+{
+  "Expiry": "2016-04-07T07:38:49.8019236Z",
+  "Token": "522703b9eb596a0f40480825$1378374980$JDBWmg34kr_mFIUFP",
+  "Purpose": "CustomerPortal",
+  "Url": "https://app.billwerk.com/portal/data/522703b9eb596a0f40480825$1378374980$JDBWIYOmg34kr_mFIUFP/"
+}

--- a/spec/pactas_itero/api/contracts_spec.rb
+++ b/spec/pactas_itero/api/contracts_spec.rb
@@ -115,4 +115,30 @@ describe PactasItero::Api::Customers do
       expect(request).to have_been_made
     end
   end
+
+  describe ".get_self_service_token_for_contract" do
+    it "requests the correct resource" do
+      client = PactasItero::Client.new(bearer_token: "bt")
+      request = stub_get("/api/v1/contracts/5357bc4f1d8dd00fa0db6c31/SelfServiceToken").to_return(
+        body: fixture("self_service_token.json"),
+        headers: { content_type: "application/json; charset=utf-8" },
+      )
+
+      client.get_self_service_token_for_contract("5357bc4f1d8dd00fa0db6c31")
+
+      expect(request).to have_been_made
+    end
+
+    it "returns a self service token" do
+      client = PactasItero::Client.new(bearer_token: "bt")
+      stub_get("/api/v1/contracts/5357bc4f1d8dd00fa0db6c31/SelfServiceToken").to_return(
+        body: fixture("self_service_token.json"),
+        headers: { content_type: "application/json; charset=utf-8" },
+      )
+
+      self_service_token = client.get_self_service_token_for_contract("5357bc4f1d8dd00fa0db6c31")
+
+      expect(self_service_token.token).to eq "522703b9eb596a0f40480825$1378374980$JDBWmg34kr_mFIUFP"
+    end
+  end
 end


### PR DESCRIPTION
Add a method get_self_service_token_for_contract implementing the
SelfServiceToken call to retrieve an access token that can
be used by customers to change their account and payment
information for a given contract.

See the [Billwerk API reference](https://developer.billwerk.io/Docs/Reference#contracts)
for details.