### PR TITLE
Replaces uses of `git ls-files` in your gemspec

### DIFF
--- a/pactas_itero.gemspec
+++ b/pactas_itero.gemspec
@@ -16,9 +16,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/webionate/pactas_itero'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split("\n")
-  spec.test_files    = `git ls-files -- spec/*`.split("\n")
-  spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  spec.files = Dir["lib/**/*.rb"] + Dir["bin/*"]
+  spec.files += Dir["[A-Z]*"] + Dir["spec/**/*"]
+  spec.test_files    = spec.files.grep(%r{^spec/})
+  spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = ">= 2.0"


### PR DESCRIPTION
The use of `git ls-files` in the gemspec file
causes fatal error warning when loading the gem.

See https://github.com/bundler/bundler/issues/2039

Solution was found here:
https://github.com/bundler/bundler/issues/2039#issuecomment-10128200