### PR TITLE
Add method to get specific customer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNRELEASED]
 ### Added
 - get a self service token for a given contract
+- get a specific customer by id
 
 ### Changed
 - update version of jruby to 9.1.5.0

--- a/lib/pactas_itero/api/customers.rb
+++ b/lib/pactas_itero/api/customers.rb
@@ -1,7 +1,7 @@
 module PactasItero
   module Api
     module Customers
-      def create_customer(options= {})
+      def create_customer(options = {})
         options = options.camelize_keys
         post "api/v1/customers", options
       end
@@ -9,6 +9,11 @@ module PactasItero
       def customers(options = {})
         options = options.camelize_keys
         get "api/v1/customers", options
+      end
+
+      def customer(customer_id, options = {})
+        options = options.camelize_keys
+        get "api/v1/customers/#{customer_id}", options
       end
 
       def update_customer(customer_id, options = {})

--- a/spec/pactas_itero/api/customers_spec.rb
+++ b/spec/pactas_itero/api/customers_spec.rb
@@ -160,6 +160,47 @@ describe PactasItero::Api::Customers do
     end
   end
 
+  describe ".customer" do
+    it "requests the correct resource" do
+      client = PactasItero::Client.new(bearer_token: "bearer_token")
+      request = stub_get("/api/v1/customers/customer-id").to_return(
+        body: fixture("customer.json"),
+        headers: { content_type: "application/json; charset=utf-8" },
+      )
+
+      client.customer("customer-id")
+
+      expect(request).to have_been_made
+    end
+
+    it "returns the customer details" do
+      client = PactasItero::Client.new(bearer_token: "bearer_token")
+      stub_get("/api/v1/customers/customer-id").to_return(
+        body: fixture("customer.json"),
+        headers: { content_type: "application/json; charset=utf-8" },
+      )
+
+      customer = client.customer("customer-id")
+
+      address = customer.address
+      expect(address.city).to eq "Example City"
+      expect(address.country).to eq "DE"
+      expect(address.house_number).to eq "42"
+      expect(address.postal_code).to eq "12345"
+      expect(address.street).to eq "Example Street"
+
+      expect(customer.company_name).to eq "Example Company"
+      expect(customer.default_bearer_medium).to eq"Email"
+      expect(customer.email_address).to eq "jane.doe@example.com"
+      expect(customer.external_customer_id).to eq "1234"
+      expect(customer.first_name).to eq "Jane"
+      expect(customer.language).to eq "de-DE"
+      expect(customer.last_name).to eq "Doe"
+      expect(customer.locale).to eq "de-DE"
+      expect(customer.vat_id).to eq "DE123456710"
+    end
+  end
+
   describe '.update_customer' do
     it 'requests the correct resource' do
       client = PactasItero::Client.new(bearer_token: 'bt')


### PR DESCRIPTION
Adds a method to GET a specific customer via ID.
The corresponding resource URI is `/customers/:customer_id`.
See the [Billwerk API Documentation](https://developer.billwerk.io/Docs/Reference#customers) for more information.