### PR TITLE
Update versions of jruby and rbx in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
+  - ruby-head
   - 2.3.1
   - 2.2.4
   - 2.1.7
   - 2.0.0
-  - jruby
-  - rbx-2
+  - jruby-head
+  - jruby-9.1.5.0
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
 notifications:
   flowdock:
     secure: fSZxX5z3bHWT8aCFKBFrDDt5o3Jb6EFWcm+pAcMabpfDHc4iktWuCUlSM405798TRdKdws1A2RncQGYiQyLbqNvtLz48dvj4BxgYW7P/vg0koN+I/H2MjpZeuIQ7BRSEJIq2sAYNVya+hSil+SPEBMTngJiP6VYG0dm6fFnRkyk=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 - get a self service token for a given contract
 
 ### Changed
+- update version of jruby to 9.1.5.0
 
 ### Deprecated
 
 ### Removed
 - support for ruby version 1.8.x and 1.9.x
+- support for rubinius
 
 ### Fixed
 


### PR DESCRIPTION
Builds for jruby were failing because the default version used 1.9 mode,
but the `public_suffix` gem required a ruby version >= 2.0. This commit
includes a version of jruby fixed at 9.1.5.0, which uses ruby 2.3.1.

Builds for Rubinius (rbx) were failing as well and can not be fixed at
this point of time. I suggest to allow rbx builds to fail, adding them
to the "experimental" builds. See the [TravisCI docs](https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail) for more information.

I also suggest adding `ruby-head` and `jruby-head` to the experimental
builds, since they will always point to the newest versions available.