### PR TITLE
Fixes "Stack level too deep" issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - support for rubinius
 
 ### Fixed
+- issue where stubbing the PactasItero.client method caused
+  a "Stack level too deep" error on rspec > 3.3
 
 ### Security
 

--- a/lib/pactas_itero.rb
+++ b/lib/pactas_itero.rb
@@ -2,7 +2,6 @@ require 'pactas_itero/client'
 require 'pactas_itero/default'
 
 module PactasItero
-
   class << self
     include PactasItero::Configurable
 
@@ -10,18 +9,17 @@ module PactasItero
     #
     # @return [PactasItero::Client] API wrapper
     def client
-      @client = PactasItero::Client.new(options)
-      @client
+      PactasItero::Client.new(options)
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      (respond_to?(:client) && client.respond_to?(method_name, include_private)) || super
+      method_name != :client && client.respond_to?(method_name, include_private) || super
     end
 
     private
 
     def method_missing(method_name, *args, &block)
-      if respond_to?(:client) && client.respond_to?(method_name)
+      if method_name != :client && client.respond_to?(method_name)
         client.send(method_name, *args, &block)
       else
         super

--- a/pactas_itero.gemspec
+++ b/pactas_itero.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency('faraday_middleware', '~> 0.9.1')
   spec.add_dependency('rash', '~> 0.4.0')
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency "rspec", '~> 3.0'
-  spec.add_development_dependency("simplecov", "~> 0")
-  spec.add_development_dependency("webmock", "~> 1.18", ">= 1.18.0")
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency "rspec", '~> 3.5.0'
+  spec.add_development_dependency("simplecov", "~> 0.12.0")
+  spec.add_development_dependency("webmock", "~> 2.3")
 end

--- a/spec/pactas_itero/api/oauth_spec.rb
+++ b/spec/pactas_itero/api/oauth_spec.rb
@@ -1,39 +1,43 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe PactasItero::Api::OAuth do
-
-  describe '#token' do
-    before do
-      stub_post("https://a_client_id:a_client_secret@sandbox.billwerk.com/oauth/token").with(
-        :body => { :grant_type => 'client_credentials' }
-      ).to_return(
-        :status => 200,
-        :body => fixture('bearer_token.json'),
-        :headers => {
-          :content_type => 'application/json; charset=utf-8'
-        }
+  describe "#token" do
+    it "requests the correct resource" do
+      client_credentials_request = stub_post("https://sandbox.billwerk.com/oauth/token").with(
+        basic_auth: %w(a_client_id a_client_secret),
+        body: "grant_type=client_credentials",
+        headers: {
+          "Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8",
+        },
       )
-    end
 
-    it 'requests the correct resource' do
-      client = PactasItero::Client.new(client_id: 'a_client_id', client_secret: 'a_client_secret')
+      client = PactasItero::Client.new(client_id: "a_client_id", client_secret: "a_client_secret")
 
       client.token
 
-      expect(a_post("https://a_client_id:a_client_secret@sandbox.billwerk.com/oauth/token").with(
-        :body => "grant_type=client_credentials",
-        :headers => {
-          'Content-Type'=>'application/x-www-form-urlencoded; charset=UTF-8'
-        }
-      )).to have_been_made
+      expect(client_credentials_request).to have_been_made
     end
 
-    it 'returns the bearer token' do
-      client = PactasItero::Client.new(client_id: 'a_client_id', client_secret: 'a_client_secret')
+    it "returns the bearer token" do
+      stub_post("https://sandbox.billwerk.com/oauth/token").with(
+        basic_auth: %w(a_client_id a_client_secret),
+        body: "grant_type=client_credentials",
+        headers: {
+          "Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8",
+        },
+      ).to_return(
+        status: 200,
+        body: fixture("bearer_token.json"),
+        headers: {
+          content_type: "application/json; charset=utf-8",
+        },
+      )
+
+      client = PactasItero::Client.new(client_id: "a_client_id", client_secret: "a_client_secret")
       bearer_token = client.token
 
-      expect(bearer_token.access_token).to eq('top_secret_access_token')
-      expect(bearer_token.token_type).to eq('bearer')
+      expect(bearer_token.access_token).to eq("top_secret_access_token")
+      expect(bearer_token.token_type).to eq("bearer")
       expect(bearer_token.expires).to eq(0)
     end
   end

--- a/spec/pactas_itero_spec.rb
+++ b/spec/pactas_itero_spec.rb
@@ -16,6 +16,13 @@ describe PactasItero do
     it "creates new client everytime" do
       expect(PactasItero.client).to_not eq(PactasItero.client)
     end
+
+    it "allows stubbing the method" do
+      pactas_client = instance_double(PactasItero::Client)
+      allow(PactasItero).to receive(:client).and_return(pactas_client)
+
+      expect(PactasItero.client).to be_kind_of RSpec::Mocks::InstanceVerifyingDouble
+    end
   end
 
   describe ".configure" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require 'simplecov'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   SimpleCov::Formatter::HTMLFormatter,
-]
+)
 
 SimpleCov.start do
   add_filter '/spec/'


### PR DESCRIPTION
* Fixes issue where stubbing the PactasItero.client method
caused a "Stack level too deep" error on rspec > 3.3

* Fixes failing specs due to gem updates