### PR TITLE
Revert faraday_middleware version update

### DIFF
--- a/pactas_itero.gemspec
+++ b/pactas_itero.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0"
 
-  spec.add_dependency("faraday_middleware", ">= 0.12.0")
-  spec.add_dependency("rash_alt")
+  spec.add_dependency("faraday_middleware", ">= 0.9.1", "< 0.12")
+  spec.add_dependency("rash")
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/spec/pactas_itero/api/payment_transactions_spec.rb
+++ b/spec/pactas_itero/api/payment_transactions_spec.rb
@@ -44,18 +44,18 @@ describe PactasItero::Api::PaymentTransactions do
       expect(transaction.status_history).to eq(
         [
           {
-            "Amount" => 11.89,
-            "HttpCode" => 0,
-            "Preauth" => false,
-            "Status" => "InProgress",
-            "Timestamp" => "2017-07-30T13:33:49.9760000Z",
+            "amount" => 11.89,
+            "http_code" => 0,
+            "preauth" => false,
+            "status" => "InProgress",
+            "timestamp" => "2017-07-30T13:33:49.9760000Z",
           },
           {
-            "Amount" => 11.89,
-            "HttpCode" => 0,
-            "Preauth" => false,
-            "Status" => "Succeeded",
-            "Timestamp" => "2017-07-30T13:33:49.9900000Z",
+            "amount" => 11.89,
+            "http_code" => 0,
+            "preauth" => false,
+            "status" => "Succeeded",
+            "timestamp" => "2017-07-30T13:33:49.9900000Z",
           },
         ],
       )


### PR DESCRIPTION
Reverts the version back to `< 0.12` since there were version conflicts
with our main app.